### PR TITLE
 🌈feat : 페이지별 헤더 스타일 추가

### DIFF
--- a/src/common/Header/index.js
+++ b/src/common/Header/index.js
@@ -7,7 +7,9 @@ import { IconButton } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router-dom'
 import { useRef } from 'react'
+import useDetailLocation from 'hooks/use-detail-location'
 const Header = () => {
+	const isDetail = useDetailLocation()
 	const setToggle = useSetRecoilState(toggleUiAtom)
 	const navigate = useNavigate()
 	const inputRef = useRef('')
@@ -27,16 +29,15 @@ const Header = () => {
 					position: 'fixed',
 					width: '100%',
 					height: '50px',
-					backgroundColor: '#F1404B',
+					backgroundColor: isDetail ? 'transparent' : '#F1404B',
 					display: 'flex',
-					zIndex: 10,
+					zIndex: 100,
 				}}
 			>
 				<Box
 					sx={{
 						width: 200,
 						height: '50px',
-						backgroundColor: '#F1404B',
 					}}
 				>
 					<S.InnerBox onClick={ToggleHandling}>
@@ -45,10 +46,14 @@ const Header = () => {
 					</S.InnerBox>
 				</Box>
 				<SearchContainer onSubmit={searchKeyword}>
-					<IconButton type="button" sx={{ p: '10px' }} aria-label="search">
+					<IconButton
+						type="button"
+						sx={{ p: '10px', color: isDetail ? '#fff' : '#000' }}
+						aria-label="search"
+					>
 						<SearchIcon />
 					</IconButton>
-					<SearchBox>
+					<SearchBox isDetail={isDetail}>
 						<SearchBar ref={inputRef} type="text" />
 					</SearchBox>
 				</SearchContainer>
@@ -72,7 +77,10 @@ const SearchBar = styled.input`
 
 const SearchBox = styled.div`
 	padding: 5px;
-	border: 1px solid black;
+	border: 1px solid ${({ isDetail }) => (isDetail ? '#fff' : '#000')};
+	input {
+		color: ${({ isDetail }) => (isDetail ? '#fff' : '#000')};
+	}
 `
 
 const InnerBox = styled.div`

--- a/src/common/Layout/index.js
+++ b/src/common/Layout/index.js
@@ -3,6 +3,7 @@ import Footer from 'common/Footer'
 import Header from 'common/Header'
 import ToolBar from 'common/ToolBar'
 import API_KEYWORD from 'consts/apiKeyword'
+import useDetailLocation from 'hooks/use-detail-location'
 import { useEffect } from 'react'
 import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
@@ -12,6 +13,7 @@ const { Outlet, useNavigate } = require('react-router-dom')
 const Layout = () => {
 	const showToggle = useRecoilValue(toggleUiAtom)
 	const navigate = useNavigate()
+	const isDetail = useDetailLocation()
 
 	useEffect(() => {
 		navigate(API_KEYWORD.POPULAR)
@@ -21,7 +23,7 @@ const Layout = () => {
 			<Header />
 			<ToolBar />
 			<S.Wrapper>
-				<S.Box showToggle={showToggle}>
+				<S.Box isDetail={isDetail} showToggle={showToggle}>
 					<Outlet />
 				</S.Box>
 			</S.Wrapper>
@@ -38,7 +40,7 @@ const Wrapper = styled.div`
 	background-color: #252c41;
 `
 const Box = styled.div`
-	padding-top: 60px;
+	padding-top: ${({ isDetail }) => (isDetail ? '0' : '60px')};
 	margin-left: ${({ showToggle }) => (showToggle ? '200px' : '0px')};
 	transition: 1s;
 	color: white;

--- a/src/hooks/use-detail-location.js
+++ b/src/hooks/use-detail-location.js
@@ -1,0 +1,10 @@
+import { useLocation } from 'react-router-dom'
+
+const useDetailLocation = () => {
+	const location = useLocation()
+
+	if (!location.pathname.includes('detail')) return false
+	return true
+}
+
+export default useDetailLocation


### PR DESCRIPTION
### Summary

- 페이지별 헤더의 배경 색상을 다르게 설정

### Changes

- 변경 전 : 메인과 상세 모두 분홍색 배경의 헤더 노출
- 변경 후 : 상세페이지에서는 투명한 배경으로 나옴

### 특이사항 (Optional)

- 현재 페이지가 상세페이지이면 `true`를 리턴하는 `useDetailLocation` custom hook 생성

### Screenshots (Optional)

![image](https://github.com/KIT-Frontend-Team2/week15-movie-trailer-project/assets/11881721/92a2a857-e888-41c6-8496-6efda3a6bc9d)
메인

![image](https://github.com/KIT-Frontend-Team2/week15-movie-trailer-project/assets/11881721/315928e8-93f1-40fa-b17e-4211d0fa02c5)
상세