### PR TITLE
 🌈feat : 미디어쿼리 분기점 hook 함수 추가

### DIFF
--- a/src/hooks/use-device.js
+++ b/src/hooks/use-device.js
@@ -1,0 +1,13 @@
+import { useMediaQuery } from '@mui/material'
+
+export const useDevice = () => {
+	const isMobile = useMediaQuery('(max-width: 425px)')
+	const isTablet = useMediaQuery('(min-width: 426px) and (max-width: 1023px)')
+	const isDesktop = useMediaQuery('(min-width: 1024px)')
+
+	return {
+		isMobile,
+		isTablet,
+		isDesktop,
+	}
+}


### PR DESCRIPTION
### Summary

- 미디어쿼리 분기점 hook 함수 useDevice 추가

### Changes

- 미디어쿼리 분기점 hook 함수 추가
- 사용 방법 : `const { isDesktop } = useDevice()`


### 특이사항 (Optional)

분기점 기준
- 모바일 : 425px 이하
- 태블릿 : 426px 이상 1023px 이하
- 데스크탑 : 1024px 이상
